### PR TITLE
Add proof verification example in Solidity to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ contract Verifier {
 ```
 
 1. Store the tree root in your contract.
-2. Compute the [leaf hash](#treeleafhash) for the provided `addr` and `amount` ABI encoded values.
+2. Compute the [leaf hash](#leaf-hash) for the provided `addr` and `amount` ABI encoded values.
 3. Verify it using [`MerkleProof`]'s `verify` function.
 4. Use the verification to make further operations on the contract. (Consider you may want to add a mechanism to prevent reuse of a leaf/proof).
 
@@ -119,6 +119,8 @@ This library works on "standard" merkle trees designed for Ethereum smart contra
 - The leaves are double-hashed to prevent [second preimage attacks].
 
 [second preimage attacks]: https://flawed.net.nz/2018/02/21/attacking-merkle-trees-with-a-second-preimage-attack/
+
+### Leaf Hash
 
 From the last three points we get that the hash of a leaf in the tree with value `[addr, amount]` can be computed in Solidity as follows:
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ contract Verifier {
 1. Store the tree root in your contract.
 2. Compute the [leaf hash](#treeleafhash) for the provided `addr` and `amount` ABI encoded values.
 3. Verify it using [`MerkleProof`]'s `verify` function.
-4. Use the verification to make further operations on the contract. (Consider you may want to add a mechanism to reuse the proof for a particular leaf).
+4. Use the verification to make further operations on the contract. (Consider you may want to add a mechanism to prevemt reuse of a leaf/proof).
 
 ## Standard Merkle Trees
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ contract Verifier {
 1. Store the tree root in your contract.
 2. Compute the [leaf hash](#leaf-hash) for the provided `addr` and `amount` ABI encoded values.
 3. Verify it using [`MerkleProof`]'s `verify` function.
-4. Use the verification to make further operations on the contract. (Consider you may want to add a mechanism to prevent reuse of a leaf/proof).
+4. Use the verification to make further operations on the contract. (Consider you may want to add a mechanism to prevent reuse of a leaf).
 
 ## Standard Merkle Trees
 

--- a/README.md
+++ b/README.md
@@ -92,11 +92,13 @@ contract Verifier {
         bytes32[] memory proof,
         address addr,
         uint256 amount
-    ) public view returns (bool) {
+    ) public {
         // (2)
         bytes32 leaf = keccak256(bytes.concat(keccak256(abi.encode(addr, amount))));
         // (3)
-        return MerkleProof.verify(proof, root, leaf);
+        bool verified = MerkleProof.verify(proof, root, leaf), "Invalid proof");
+        // (4)
+        // ...
     }
 }
 ```
@@ -104,6 +106,7 @@ contract Verifier {
 1. Store the tree root in your contract.
 2. Compute the [leaf hash](#treeleafhash) for the provided `addr` and `amount` ABI encoded values.
 3. Verify it using [`MerkleProof`]'s `verify` function.
+4. Use the verification to make further operations on the contract. (Consider you may want to add a mechanism to reuse the proof for a particular leaf).
 
 ## Standard Merkle Trees
 

--- a/README.md
+++ b/README.md
@@ -102,11 +102,8 @@ contract Verifier {
 ```
 
 1. Store the tree root in your contract.
-2. Compute the [leaf hash](#leaf-hash) for the provided `addr` and `amount` ABI encoded values.
+2. Compute the [leaf hash](#treeleafhash) for the provided `addr` and `amount` ABI encoded values.
 3. Verify it using [`MerkleProof`]'s `verify` function.
-
-> **Note**
-> The provided example is not suitable for production purposes since it assumes the `root` will never be changed. Consider adding a mechanism to securely update the `root`
 
 ## Standard Merkle Trees
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,42 @@ for (const [i, v] of tree.entries()) {
 
 In practice this might be done in a frontend application prior to submitting the proof on-chain, with the address looked up being that of the connected wallet.
 
-See [`MerkleProof`] for documentation on how to validate the proof in Solidity.
+### Validating a Proof in Solidity
+
+Once you've gotten the proof, it can be validated in Solidity using [`MerkleProof`] with the following example:
+
+```solidity
+pragma solidity ^0.8.0;
+
+import "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
+
+contract Verifier {
+    bytes32 private root;
+
+    constructor(bytes32 _root) {
+        // (1)
+        root = _root;
+    }
+
+    function verify(
+        bytes32[] memory proof,
+        address addr,
+        uint256 amount
+    ) public view returns (bool) {
+        // (2)
+        bytes32 leaf = keccak256(bytes.concat(keccak256(abi.encode(addr, amount))));
+        // (3)
+        return MerkleProof.verify(proof, root, leaf);
+    }
+}
+```
+
+1. Load the tree's root to your contract.
+2. Compute the leaf's value for the provided `addr` and `amount` ABI encoded values.
+3. Verify it using [`MerkleProof`]'s `verify` function.
+
+> **Note**
+> The provided example is not suitable for production purposes since it assumes the `_root` will never be changed. Consider adding a mechanism to securely update the `_root`
 
 ## Standard Merkle Trees
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ contract Verifier {
 }
 ```
 
-1. Load the tree's root to your contract.
+1. Store the tree root in your contract.
 2. Compute the leaf's value for the provided `addr` and `amount` ABI encoded values.
 3. Verify it using [`MerkleProof`]'s `verify` function.
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ In practice this might be done in a frontend application prior to submitting the
 
 ### Validating a Proof in Solidity
 
-Once you've gotten the proof, it can be validated in Solidity using [`MerkleProof`] with the following example:
+Once the proof has been generated, it can be validated in Solidity using [`MerkleProof`] as in the following example:
 
 ```solidity
 pragma solidity ^0.8.0;

--- a/README.md
+++ b/README.md
@@ -102,7 +102,7 @@ contract Verifier {
 ```
 
 1. Store the tree root in your contract.
-2. Compute the leaf's value for the provided `addr` and `amount` ABI encoded values.
+2. Compute the [leaf hash](#leaf-hash) for the provided `addr` and `amount` ABI encoded values.
 3. Verify it using [`MerkleProof`]'s `verify` function.
 
 > **Note**

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ contract Verifier {
 3. Verify it using [`MerkleProof`]'s `verify` function.
 
 > **Note**
-> The provided example is not suitable for production purposes since it assumes the `_root` will never be changed. Consider adding a mechanism to securely update the `_root`
+> The provided example is not suitable for production purposes since it assumes the `root` will never be changed. Consider adding a mechanism to securely update the `root`
 
 ## Standard Merkle Trees
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ contract Verifier {
 1. Store the tree root in your contract.
 2. Compute the [leaf hash](#treeleafhash) for the provided `addr` and `amount` ABI encoded values.
 3. Verify it using [`MerkleProof`]'s `verify` function.
-4. Use the verification to make further operations on the contract. (Consider you may want to add a mechanism to prevemt reuse of a leaf/proof).
+4. Use the verification to make further operations on the contract. (Consider you may want to add a mechanism to prevent reuse of a leaf/proof).
 
 ## Standard Merkle Trees
 


### PR DESCRIPTION
## Description
As per #5, an example of how to generate a proof is added to the README 