### PR TITLE
Enable proof verification without full tree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.3
+
+- Added `StandardMerkleTree.verify` static method for verification of a proof for given root, leaf, and leaf encoding.
+
 ## 1.0.2
 
 - Added `StandardMerkleTree` methods `verify` and `verifyMultiProof`.

--- a/README.md
+++ b/README.md
@@ -149,10 +149,10 @@ Creates a standard merkle tree out of an array of the elements in the tree, alon
 > **Note**
 > Consider reading the array of elements from a CSV file for easy interoperability with spreadsheets or other data processing pipelines.
 
-### `StandardMerkleTree.verifyWithRoot`
+### `StandardMerkleTree.verify`
 
 ```typescript
-const verified = StandardMerkleTree.verifyWithRoot([alice, '100'], proof, root, ['address', 'uint']);
+const verified = StandardMerkleTree.verify(root, ['address', 'uint'], [alice, '100'], proof);
 ```
 
 Returns a boolean that is `true` when the proof verifies that the value is contained in the tree given only the proof, merkle root, and encoding.

--- a/README.md
+++ b/README.md
@@ -149,6 +149,14 @@ Creates a standard merkle tree out of an array of the elements in the tree, alon
 > **Note**
 > Consider reading the array of elements from a CSV file for easy interoperability with spreadsheets or other data processing pipelines.
 
+### `StandardMerkleTree.verifyWithRoot`
+
+```typescript
+const verified = StandardMerkleTree.verifyWithRoot([alice, '100'], proof, root, ['address', 'uint']);
+```
+
+Returns a boolean that is `true` when the proof verifies that the value is contained in the tree given only the proof, merkle root, and encoding.
+
 ### `tree.root`
 
 ```typescript
@@ -219,14 +227,6 @@ tree.verifyMultiProof({ proof, proofFlags, leaves });
 ```
 
 Returns a boolean that is `true` when the multi-proof verifies that the values are contained in the tree.
-
-### `StandardMerkleTree.verifyWithRoot`
-
-```typescript
-const verified = StandardMerkleTree.verifyWithRoot([alice, '100'], proof, root, ['address', 'uint']);
-```
-
-Returns a boolean that is `true` when the proof verifies that the value is contained in the tree given only the proof, merkle root, and encoding.
 
 ### `tree.entries`
 

--- a/README.md
+++ b/README.md
@@ -220,6 +220,14 @@ tree.verifyMultiProof({ proof, proofFlags, leaves });
 
 Returns a boolean that is `true` when the multi-proof verifies that the values are contained in the tree.
 
+### `StandardMerkleTree.verifyWithRoot`
+
+```typescript
+const verified = StandardMerkleTree.verifyWithRoot([alice, '100'], proof, root, ['address', 'uint']);
+```
+
+Returns a boolean that is `true` when the proof verifies that the value is contained in the tree given only the proof, merkle root, and encoding.
+
 ### `tree.entries`
 
 ```typescript

--- a/src/standard.test.ts
+++ b/src/standard.test.ts
@@ -38,8 +38,18 @@ describe('standard merkle tree', () => {
     for (const [, leaf] of t.entries()) {
       const proof = t.getProof(leaf);
 
-      assert(StandardMerkleTree.verifyWithRoot(leaf, proof, t.root, ['string']));
+      assert(StandardMerkleTree.verify(t.root, ['string'], leaf, proof));
     }
+  });
+
+  it('rejects invalid proof using static verify method', () => {
+    const { t } = characters('abcdef');
+    const { t: fakeTree } = characters('xyz');
+
+    const testLeaf = ['x'];
+    const proof = fakeTree.getProof(testLeaf);
+
+    assert(!StandardMerkleTree.verify(t.root, ['string'], testLeaf, proof));
   });
 
   it('generates valid multiproofs', () => {

--- a/src/standard.test.ts
+++ b/src/standard.test.ts
@@ -32,6 +32,16 @@ describe('standard merkle tree', () => {
     }
   });
 
+  it('generates valid single proofs for all leaves from root and encoding', () => {
+    const { t } = characters('abcdef');
+
+    for (const [, leaf] of t.entries()) {
+      const proof = t.getProof(leaf);
+
+      assert(StandardMerkleTree.verifyWithRoot(leaf, proof, t.root, ['string']));
+    }
+  });
+
   it('generates valid multiproofs', () => {
     const { t, l } = characters('abcdef');
 

--- a/src/standard.ts
+++ b/src/standard.ts
@@ -61,6 +61,10 @@ export class StandardMerkleTree<T extends any[]> {
     );
   }
 
+  static verifyWithRoot(leaf: any[], proof: string[], root: string, leafEncoding: string[]): boolean {
+    return StandardMerkleTree._verifyWithRoot(standardLeafHash(leaf, leafEncoding), proof.map(hexToBytes), root);
+  }
+
   dump(): StandardMerkleTreeData<T> {
     return {
       format:      'standard-v1',
@@ -148,6 +152,11 @@ export class StandardMerkleTree<T extends any[]> {
   private _verify(leafHash: Bytes, proof: Bytes[]): boolean {
     const impliedRoot = processProof(leafHash, proof);
     return equalsBytes(impliedRoot, this.tree[0]!);
+  }
+
+  private static _verifyWithRoot(leafHash: Bytes, proof: Bytes[], root: string): boolean {
+    const impliedRoot = processProof(leafHash, proof);
+    return equalsBytes(impliedRoot, hexToBytes(root));
   }
 
   verifyMultiProof(multiproof: MultiProof<string, number | T>): boolean {

--- a/src/standard.ts
+++ b/src/standard.ts
@@ -61,8 +61,9 @@ export class StandardMerkleTree<T extends any[]> {
     );
   }
 
-  static verifyWithRoot(leaf: any[], proof: string[], root: string, leafEncoding: string[]): boolean {
-    return StandardMerkleTree._verifyWithRoot(standardLeafHash(leaf, leafEncoding), proof.map(hexToBytes), root);
+  static verifyWithRoot<T extends any[]>(leaf: T[], proof: string[], root: string, leafEncoding: string[]): boolean {
+    const impliedRoot = processProof(standardLeafHash(leaf, leafEncoding), proof.map(hexToBytes));
+    return equalsBytes(impliedRoot, hexToBytes(root));
   }
 
   dump(): StandardMerkleTreeData<T> {
@@ -152,11 +153,6 @@ export class StandardMerkleTree<T extends any[]> {
   private _verify(leafHash: Bytes, proof: Bytes[]): boolean {
     const impliedRoot = processProof(leafHash, proof);
     return equalsBytes(impliedRoot, this.tree[0]!);
-  }
-
-  private static _verifyWithRoot(leafHash: Bytes, proof: Bytes[], root: string): boolean {
-    const impliedRoot = processProof(leafHash, proof);
-    return equalsBytes(impliedRoot, hexToBytes(root));
   }
 
   verifyMultiProof(multiproof: MultiProof<string, number | T>): boolean {

--- a/src/standard.ts
+++ b/src/standard.ts
@@ -61,7 +61,7 @@ export class StandardMerkleTree<T extends any[]> {
     );
   }
 
-  static verifyWithRoot<T extends any[]>(leaf: T[], proof: string[], root: string, leafEncoding: string[]): boolean {
+  static verify<T extends any[]>(root: string, leafEncoding: string[], leaf: T, proof: string[]): boolean {
     const impliedRoot = processProof(standardLeafHash(leaf, leafEncoding), proof.map(hexToBytes));
     return equalsBytes(impliedRoot, hexToBytes(root));
   }

--- a/src/standard.ts
+++ b/src/standard.ts
@@ -60,6 +60,7 @@ export class StandardMerkleTree<T extends any[]> {
       data.leafEncoding,
     );
   }
+
   static verifyWithRoot<T extends any[]>(leaf: T[], proof: string[], root: string, leafEncoding: string[]): boolean {
     const impliedRoot = processProof(standardLeafHash(leaf, leafEncoding), proof.map(hexToBytes));
     return equalsBytes(impliedRoot, hexToBytes(root));


### PR DESCRIPTION
In some cases it may be necessary to validate a leaf when you only have the root and encoding information. Currently this is not possible. With this new verifyWithRoot static method it is now possible.