### PR TITLE
Add invariant validation in processMultiProof

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.5
+
+- Make `processMultiProof` more robust by validating invariants.
+
 ## 1.0.4
 
 - Added `StandardMerkleTree.verifyMultiProof` static method.

--- a/src/core.ts
+++ b/src/core.ts
@@ -120,9 +120,16 @@ export function processMultiProof(multiproof: MultiProof<Bytes>): Bytes {
   const proof = multiproof.proof.concat(); // copy
 
   for (const flag of multiproof.proofFlags) {
-    const a = stack.shift()!;
-    const b = flag ? stack.shift()! : proof.shift()!;
+    const a = stack.shift();
+    const b = flag ? stack.shift() : proof.shift();
+    if (a === undefined || b === undefined) {
+      throw new Error('Broken invariant');
+    }
     stack.push(hashPair(a, b));
+  }
+
+  if (stack.length + proof.length !== 1) {
+      throw new Error('Broken invariant');
   }
 
   return stack.pop() ?? proof.shift()!;


### PR DESCRIPTION
Related to GHSA-wprv-93r4-jj2p, although this code does not appear affected by the same issue since we don't allocate a big array at the beginning. The same bad multiproof would result in reading `undefined` from one of the temporary arrays, and this breaks the code regardless. This PR makes it more explicit and removes the use of non-null assertions `!` which were assuming the invariant always holds.