### PR TITLE
1.0.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## 1.0.6
 
 - Added an option to disable leaf sorting.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@openzeppelin/merkle-tree",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@openzeppelin/merkle-tree",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "MIT",
       "dependencies": {
         "@ethersproject/abi": "^5.7.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openzeppelin/merkle-tree",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "Utilities to work with merkle trees",
   "repository": "github:OpenZeppelin/merkle-tree",
   "main": "dist/index.js",


### PR DESCRIPTION
I'd like to release the current version so we can move forward with testing in https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3617