### PR TITLE
feat: optional encoder arg for standardLeafHash

### DIFF
--- a/src/hashes.ts
+++ b/src/hashes.ts
@@ -4,9 +4,16 @@ import { BytesLike, HexString, concat, compare } from './bytes';
 
 export type LeafHash<T> = (leaf: T) => HexString;
 export type NodeHash = (left: BytesLike, right: BytesLike) => HexString;
+export type Encoder = {
+  encode: (types: string[], values: any[]) => string;
+};
 
-export function standardLeafHash<T extends any[]>(types: string[], value: T): HexString {
-  return keccak256(keccak256(defaultAbiCoder.encode(types, value)));
+export function standardLeafHash<T extends any[]>(
+  types: string[],
+  value: T,
+  encoder: Encoder = defaultAbiCoder,
+): HexString {
+  return keccak256(keccak256(encoder.encode(types, value)));
 }
 
 export function standardNodeHash(a: BytesLike, b: BytesLike): HexString {

--- a/src/standard.ts
+++ b/src/standard.ts
@@ -1,8 +1,9 @@
+import { defaultAbiCoder } from '@ethersproject/abi';
 import { BytesLike, HexString, toHex } from './bytes';
 import { MultiProof, processProof, processMultiProof } from './core';
 import { MerkleTreeData, MerkleTreeImpl } from './merkletree';
 import { MerkleTreeOptions } from './options';
-import { standardLeafHash } from './hashes';
+import { Encoder, standardLeafHash } from './hashes';
 import { validateArgument } from './utils/errors';
 
 export interface StandardMerkleTreeData<T extends any[]> extends MerkleTreeData<T> {
@@ -15,44 +16,58 @@ export class StandardMerkleTree<T extends any[]> extends MerkleTreeImpl<T> {
     protected readonly tree: HexString[],
     protected readonly values: StandardMerkleTreeData<T>['values'],
     protected readonly leafEncoding: string[],
+    protected readonly encoder: Encoder = defaultAbiCoder,
   ) {
-    super(tree, values, leaf => standardLeafHash(leafEncoding, leaf));
+    super(tree, values, leaf => standardLeafHash(leafEncoding, leaf, encoder));
   }
 
   static of<T extends any[]>(
     values: T[],
     leafEncoding: string[],
     options: MerkleTreeOptions = {},
+    encoder: Encoder = defaultAbiCoder,
   ): StandardMerkleTree<T> {
     // use default nodeHash (standardNodeHash)
-    const [tree, indexedValues] = MerkleTreeImpl.prepare(values, options, leaf => standardLeafHash(leafEncoding, leaf));
-    return new StandardMerkleTree(tree, indexedValues, leafEncoding);
+    const [tree, indexedValues] = MerkleTreeImpl.prepare(values, options, leaf =>
+      standardLeafHash(leafEncoding, leaf, encoder),
+    );
+    return new StandardMerkleTree(tree, indexedValues, leafEncoding, encoder);
   }
 
-  static load<T extends any[]>(data: StandardMerkleTreeData<T>): StandardMerkleTree<T> {
+  static load<T extends any[]>(
+    data: StandardMerkleTreeData<T>,
+    encoder: Encoder = defaultAbiCoder,
+  ): StandardMerkleTree<T> {
     validateArgument(data.format === 'standard-v1', `Unknown format '${data.format}'`);
     validateArgument(data.leafEncoding !== undefined, 'Expected leaf encoding');
 
-    const tree = new StandardMerkleTree(data.tree, data.values, data.leafEncoding);
+    const tree = new StandardMerkleTree(data.tree, data.values, data.leafEncoding, encoder);
     tree.validate();
     return tree;
   }
 
-  static verify<T extends any[]>(root: BytesLike, leafEncoding: string[], leaf: T, proof: BytesLike[]): boolean {
+  static verify<T extends any[]>(
+    root: BytesLike,
+    leafEncoding: string[],
+    leaf: T,
+    proof: BytesLike[],
+    encoder: Encoder = defaultAbiCoder,
+  ): boolean {
     // use default nodeHash (standardNodeHash) for processProof
-    return toHex(root) === processProof(standardLeafHash(leafEncoding, leaf), proof);
+    return toHex(root) === processProof(standardLeafHash(leafEncoding, leaf, encoder), proof);
   }
 
   static verifyMultiProof<T extends any[]>(
     root: BytesLike,
     leafEncoding: string[],
     multiproof: MultiProof<BytesLike, T>,
+    encoder: Encoder = defaultAbiCoder,
   ): boolean {
     // use default nodeHash (standardNodeHash) for processMultiProof
     return (
       toHex(root) ===
       processMultiProof({
-        leaves: multiproof.leaves.map(leaf => standardLeafHash(leafEncoding, leaf)),
+        leaves: multiproof.leaves.map(leaf => standardLeafHash(leafEncoding, leaf, encoder)),
         proof: multiproof.proof,
         proofFlags: multiproof.proofFlags,
       })


### PR DESCRIPTION
This PR adds the ability to pass a custom encoder to `standardLeafHash`. This is primarily useful for developers that want to leverage the `standard-v1` merkle tree in contexts outside of the EVM where the encoding may differ.