### PR TITLE
Fix return type of renderMerkleTree

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -145,7 +145,7 @@ export function isValidMerkleTree(tree: BytesLike[], nodeHash: NodeHash = standa
   return tree.length > 0;
 }
 
-export function renderMerkleTree(tree: BytesLike[]): HexString {
+export function renderMerkleTree(tree: BytesLike[]): string {
   validateArgument(tree.length !== 0, 'Expected non-zero number of nodes');
 
   const stack: [number, number[]][] = [[0, []]];


### PR DESCRIPTION
The returned object is a general string, not an hex string.